### PR TITLE
[Trello 14] Twitter API Python Implementation

### DIFF
--- a/apis/README.md
+++ b/apis/README.md
@@ -10,6 +10,24 @@ Covidly takes advantage of four APIs to report its data - NewsAPI, Twitter, Avia
 
 Covidly uses Twitter's v2 API to fetch recent tweets. This endpoint require a bearer token from an approved Twitter Developer account.
 
+### Retrieving tweets with twitter_search_api.py
+
+Use `fetch_tweets()` to retrieve a list of tweets from Twitter's Recent Search v2 endpoint. `fetch_tweets()` is capable of taking fields, expansions, user fields, and amount of results(10-100), but also has default values provided so specifying is not necessary. 
+The output of `fetch_tweets()` is a list of objects sorted by tweet date, in the shape of:
+```
+- created_at
+- text 
+- id 
+- lang 
+- author_id
+- name 
+- username 
+- profile_image_url
+- geo_full_name *
+- geo_id *
+```
+\* These two fields are only present if the tweet has geospatial data tied to it.
+
 More documentation on the query params are available here:
 
 [API Reference](https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent)

--- a/apis/twitter_search_api.py
+++ b/apis/twitter_search_api.py
@@ -64,7 +64,7 @@ def fetch_tweets(fields=default_fields,expansions=default_expansions,user=defaul
                     t['geo_'+pk]=place_info[pk]
             author_info=users[t['author_id']]
             for ak in author_info.keys():
-                t[ak]=author_info[ak]
+                t['author_'+ak]=author_info[ak]
             final_tweets.append(t)
     #fetch tweets that were retweeted
     q_retweets=parse_query_args(ref_tweets,'tweets')
@@ -86,7 +86,7 @@ def fetch_tweets(fields=default_fields,expansions=default_expansions,user=defaul
                     t['geo_'+pk]=place_info[pk]
             author_info=users[t['author_id']]
             for ak in author_info.keys():
-                t[ak]=author_info[ak]
+                t['author_'+ak]=author_info[ak]
             final_tweets.append(t)
 
     return sorted(final_tweets,key=lambda t:t['created_at'])


### PR DESCRIPTION
## Summary
Broke down the twitter api implementation into three methods - `filter_tweets`, `parse_query_args`, and `fetch_tweets` - the first two being helper methods for `fetch_tweets`. `filter_tweets` returns true if a tweet is in English and it has no associated tweets - meaning it is not either a retweet, quote, or reply. `parse_query_args` takes a list of arguments for the twitter search endpoint and converts them into a string that can be added to the endpoint. Because of this, it is necessary to specify the type of arguments being sent, e.g. fields, expansions, etc.
## fetch_tweets
Use `fetch_tweets()` to retrieve a list of tweets from Twitter's Recent Search v2 endpoint. `fetch_tweets()` is capable of taking fields, expansions, user fields, and amount of results(10-100), but also has default values provided so specifying is not necessary. 
The output of `fetch_tweets()` is a list of objects sorted by tweet date, in the shape of:
```
- created_at
- text 
- id 
- lang 
- author_id
- name 
- username 
- profile_image_url
- geo_full_name *
- geo_id *
```
\* These two fields are only present if the tweet has geospatial data tied to it.