### PR TITLE
[Trello 35] Adding embedded tweet html to twitter API for frontend

### DIFF
--- a/apis/twitter_search_api.py
+++ b/apis/twitter_search_api.py
@@ -12,7 +12,7 @@ arg_names={'fields':"&tweet.fields="
 default_fields=['created_at','author_id','lang','possibly_sensitive']
 default_expansions=['referenced_tweets.id','author_id']#author_id necessary here as well to retrieve author info
 default_user=['name','username']
-token= 'AAAAAAAAAAAAAAAAAAAAAMbOIQEAAAAAmOubtSTp%2Fdme345uVc8IOIys4%2Fk%3DcG2CuEuQ5xQppMgn13akWLyvxwxMOiDXIyF25glaQLcnRhNXSu'
+token= ''
 results='100'
 headers = {"Authorization": "Bearer " + token}
 base_endpoint="https://api.twitter.com/2/tweets/search/recent?query="


### PR DESCRIPTION
# Before this PR
The tweet objects returned by `fetch_tweets()` had the following fields
```
- created_at
- text 
- id 
- lang 
- author_id
- name 
- username 
- profile_image_url
- geo_full_name 
- geo_id 
```
The `filter_tweets()` method would only return true for tweets that were in English and did not reference other tweets.

# After this PR

The default queries to fetch tweets and retweets have been reduced by two parameters, and the final tweet objects now only return two fields:
```
- created_at
- oembed
```
Geospatial data is no longer needed to be passed through the object as using the OEmbed component displays the data if it is present.

The filter now checks to see if a tweets content is possibly sensitive, and has also been relaxed in regards to referenced tweets - quotes and replies are now allowed as OEmbed renders both them and the original tweet

# Possible downsides?
Hitting the OEmbed endpoint increases the time it takes to retrieve the list of tweets. Additionally, the more lax filtering also contributes to this by letting more tweets make it to the final list. If the time taken to retrieve tweets is too lengthy then it may be worthwhile to look into whether it's possible to generate the OEmbed HTML without hitting the endpoint.